### PR TITLE
🐍 Pyction v2: multi-Python variants, signed images, and a formalized tag policy

### DIFF
--- a/.github/release_please_config.json
+++ b/.github/release_please_config.json
@@ -1,11 +1,5 @@
 {
   "release-type": "simple",
-  "include-v-in-tag": false,
-  "changelog-path": "CHANGELOG.md",
-  "extra-files": [{
-    "type": "generic",
-    "path": "Dockerfile",
-    "regex": "org.opencontainers.image.version=\"[0-9]+\\.[0-9]+\\.[0-9]+\"",
-    "replacement": "org.opencontainers.image.version=\"${version}\""
-  }]
+  "include-v-in-tag": true,
+  "changelog-path": "CHANGELOG.md"
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: 🏗️ and 📤 🐳 🖼️
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *"
@@ -10,17 +12,28 @@ on:
 
 env:
   GHCR_REGISTRY: ghcr.io
-  DOCKERHUB_REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
+  DEFAULT_PYTHON: "3.13"
 
 permissions:
   contents: read
   packages: write
+  id-token: write # cosign keyless signing
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build-and-push-image:
-    name: 🏗️📤 Build and push 🐳 image
+    name: 🏗️📤 Build and push 🐳 py${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    env:
+      DT_HOSTNAME: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
 
     steps:
       - name: 📦 Checkout repository
@@ -39,44 +52,105 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 🔢 Resolve image version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="0.0.0-dev.$(git rev-parse --short HEAD)"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "📌 Image version: $VERSION"
+
       - name: 🔍📝 Extract metadata (🏷️, 🏷️) for 🐳
         id: meta
         uses: docker/metadata-action@v6
         with:
           flavor: |
-            latest=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            latest=false
           images: |
             ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,priority=100,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-            type=semver,pattern={{version}},priority=150
-            type=semver,pattern={{major}}.{{minor}},priority=160
-            type=semver,pattern={{major}},priority=170
-            type=sha,enable=true,prefix={{branch}}-,suffix=,format=short,priority=300
-            type=raw,prefix={{branch}}-,value=latest,priority=200,enable=${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=latest,priority=100,enable=${{ matrix.python-version == env.DEFAULT_PYTHON && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) }}
+            type=raw,value=py${{ matrix.python-version }},priority=110,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+            type=semver,pattern={{version}},priority=150,enable=${{ matrix.python-version == env.DEFAULT_PYTHON }}
+            type=semver,pattern={{major}}.{{minor}},priority=160,enable=${{ matrix.python-version == env.DEFAULT_PYTHON }}
+            type=semver,pattern={{major}},priority=170,enable=${{ matrix.python-version == env.DEFAULT_PYTHON }}
+            type=semver,pattern={{version}},prefix=py${{ matrix.python-version }}-,priority=180
+            type=sha,prefix=py${{ matrix.python-version }}-,format=short,priority=300
+
+      - name: 🧪🏗️ Build local image for smoke test
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          push: false
+          tags: pyction-smoke:py${{ matrix.python-version }}
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            IMAGE_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=py${{ matrix.python-version }}
+          cache-to: type=gha,mode=max,scope=py${{ matrix.python-version }}
+
+      - name: 🧪 Smoke test (python, uv, git, curl, unzip)
+        run: |
+          docker run --rm pyction-smoke:py${{ matrix.python-version }} sh -ec '
+            python --version
+            uv --version
+            uvx --version
+            git --version
+            curl --version | head -n 1
+            unzip -v | head -n 1
+            python -c "import sys; expected = tuple(int(p) for p in \"${{ matrix.python-version }}\".split(\".\")); assert sys.version_info[:2] == expected, f\"expected {expected}, got {sys.version_info[:2]}\""
+          '
+          echo "✅ Smoke test passed for py${{ matrix.python-version }}"
 
       - name: Yeet 🐳 🖼️
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          provenance: mode=max
+          sbom: true
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            IMAGE_VERSION=${{ steps.version.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             ${{ steps.meta.outputs.labels }}
-            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=py${{ matrix.python-version }}
+
+      - name: 🔏 Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: 🔏 Sign image with cosign (keyless)
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            cosign sign --yes "${tag}@${DIGEST}"
+          done <<< "${TAGS}"
 
       # 🧩 Generate and upload SBOM automatically after successful build
       - name: 🧾 Install Syft
         uses: anchore/sbom-action/download-syft@v0.24.0
 
       - name: 🧩 Generate SBOM
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
         run: |
-          IMAGE_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
-          echo "📦 Generating SBOM for $IMAGE_TAG"
-          syft "$IMAGE_TAG" -o cyclonedx-json > sbom.cyclonedx.json
+          IMAGE_REF="${GHCR_REGISTRY}/${GITHUB_REPOSITORY,,}@${DIGEST}"
+          echo "📦 Generating SBOM for $IMAGE_REF"
+          syft "$IMAGE_REF" -o cyclonedx-json > sbom.cyclonedx.json
 
       - name: 🚀 Upload SBOM to Dependency-Track
+        if: matrix.python-version == env.DEFAULT_PYTHON && env.DT_HOSTNAME != ''
         uses: DependencyTrack/gh-upload-sbom@v4.1.0
         with:
           protocol: https
@@ -84,10 +158,9 @@ jobs:
           apikey: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
           project: ${{ secrets.DEPENDENCYTRACK_PROJECT }}
           bomfilename: sbom.cyclonedx.json
-          #autoCreate: true
 
       - name: 📦 Upload SBOM as artifact
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: sbom
+          name: sbom-py${{ matrix.python-version }}
           path: sbom.cyclonedx.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,16 @@ jobs:
 
     steps:
       - name: 📦 Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: ⚙️ Set up QEMU (multi-arch emulation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: 🧱 Set up Docker Buildx (multi-arch builder)
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🔑📦 Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: 🔍📝 Extract metadata (🏷️, 🏷️) for 🐳
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           flavor: |
             latest=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
@@ -56,7 +56,7 @@ jobs:
             type=raw,prefix={{branch}}-,value=latest,priority=200,enable=${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Yeet 🐳 🖼️
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -68,7 +68,7 @@ jobs:
 
       # 🧩 Generate and upload SBOM automatically after successful build
       - name: 🧾 Install Syft
-        uses: anchore/sbom-action/download-syft@v0.17.0
+        uses: anchore/sbom-action/download-syft@v0.24.0
 
       - name: 🧩 Generate SBOM
         run: |
@@ -77,17 +77,17 @@ jobs:
           syft "$IMAGE_TAG" -o cyclonedx-json > sbom.cyclonedx.json
 
       - name: 🚀 Upload SBOM to Dependency-Track
-        uses: DependencyTrack/gh-upload-sbom@v3
+        uses: DependencyTrack/gh-upload-sbom@v4.1.0
         with:
           protocol: https
-          serverHostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
-          apiKey: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+          serverhostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
+          apikey: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
           project: ${{ secrets.DEPENDENCYTRACK_PROJECT }}
-          bomFilename: sbom.cyclonedx.json
+          bomfilename: sbom.cyclonedx.json
           #autoCreate: true
 
       - name: 📦 Upload SBOM as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: sbom
           path: sbom.cyclonedx.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: 🚀 Run Release Please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           release-type: simple
           config-file: .github/release_please_config.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,19 +1,28 @@
 name: security
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 1" # weekly drift detection against fresh CVE data
 
 jobs:
   hardening:
     name: Security Hardening
-    uses: huntridge-labs/hardening-workflows/.github/workflows/reusable-security-hardening.yml@main
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@1.7.0
     permissions:
       contents: read
       security-events: write
       actions: read
+      packages: read
       pull-requests: write
       checks: write
       id-token: write
     with:
       scanners: all
-      python_version: '3.12'
+      python_version: '3.13'
       post_pr_comment: true
       enable_code_security: true
+      severity_threshold: high

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,25 @@
 # Dockerfile
-FROM python:3.13-slim
+# PYTHON_VERSION selects the base image variant (3.12 / 3.13 / 3.14).
+# The tag floats deliberately: the daily rebuild picks up upstream
+# Debian/Python security patches without manual intervention.
+ARG PYTHON_VERSION=3.13
+# UV_VERSION is pinned; bumped by Renovate on a monthly cadence.
+ARG UV_VERSION=0.11.26
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
+FROM python:${PYTHON_VERSION}-slim
+
+ARG PYTHON_VERSION
+# IMAGE_VERSION is injected by CI from the release tag (or a dev build id).
+ARG IMAGE_VERSION=dev
 
 LABEL \
   org.opencontainers.image.title="pyction" \
-  org.opencontainers.image.description="Base image with Python 3.13-slim and uv installed" \
+  org.opencontainers.image.description="Base image with Python ${PYTHON_VERSION}-slim and uv installed" \
   org.opencontainers.image.url="https://github.com/CivicActions/pyction" \
   org.opencontainers.image.source="https://github.com/CivicActions/pyction" \
-  org.opencontainers.image.version="1.0.0" \
+  org.opencontainers.image.version="${IMAGE_VERSION}" \
   org.opencontainers.image.licenses="AGPL-3.0-or-later" \
   org.opencontainers.image.vendor="CivicActions" \
   org.opencontainers.image.authors="CivicActions <info@civicactions.com>"
@@ -14,10 +27,12 @@ LABEL \
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
+# curl, git, and unzip are part of the image contract — downstream consumers rely on them.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends curl ca-certificates git unzip \
-  && curl -LsSf https://astral.sh/uv/install.sh | bash \
-  && mv /root/.local/bin/uv /usr/local/bin/uv \
-  && rm -rf /root/.local /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/*
+
+# uv from the official distroless image — pinned version, no curl | bash.
+COPY --from=uv /uv /uvx /usr/local/bin/
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,44 +1,100 @@
 # 🐍 Pyction
 *(pronounced: **"pik-shun"**)*
 
-Run Python scripts with [`uv`](https://github.com/astral-sh/uv) inside a slim, fast Docker container based on Python 3.13.
+A slim, fast Python **base image** with [`uv`](https://github.com/astral-sh/uv) preinstalled — built for downstream images, CI jobs, and containerized scripts.
 
-[![build](https://github.com/CivicActions/pyction/actions/workflows/build.yml/badge.svg)](https://github.com/CivicActions/pyction/actions/workflows/build.yml) [![updated](https://img.shields.io/github/last-commit/CivicActions/pyction?label=updated&logo=github)](https://github.com/CivicActions/pyction/commits/main)
+[![build](https://github.com/CivicActions/pyction/actions/workflows/build.yml/badge.svg)](https://github.com/CivicActions/pyction/actions/workflows/build.yml) [![security](https://github.com/CivicActions/pyction/actions/workflows/security.yml/badge.svg)](https://github.com/CivicActions/pyction/actions/workflows/security.yml) [![release](https://img.shields.io/github/v/release/CivicActions/pyction?logo=github)](https://github.com/CivicActions/pyction/releases) [![updated](https://img.shields.io/github/last-commit/CivicActions/pyction?label=updated&logo=github)](https://github.com/CivicActions/pyction/commits/main)
+
+![python](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue?logo=python&logoColor=white) ![arch](https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey) [![signed](https://img.shields.io/badge/images-cosign%20signed-2ea44f?logo=sigstore)](#-security--provenance)
 
 ## 🔧 Usage
 
-```yaml
-- name: Run Python Script in pyction
-  uses: civicactions/pyction@v1
-  with:
-    script: |
-      uv run your_script.py
-      uv run -m your_thing
+### As a base image (primary use case)
+
+```dockerfile
+FROM ghcr.io/civicactions/pyction:1
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+COPY . .
+CMD ["uv", "run", "your_script.py"]
 ```
 
-## 💡 Features
+### Run a script directly
 
-- Based on `ghcr.io/civicactions/pyction`
-- Runs inside Docker with full repo access
-- `uv` preinstalled
-- Your `pyproject.toml` is automatically respected
+```bash
+docker run --rm -v "$PWD:/app" ghcr.io/civicactions/pyction:latest uv run your_script.py
+```
 
-## 🔍 Inputs
-
-| Name   | Required | Description                            |
-|--------|----------|----------------------------------------|
-| script | ✅        | Shell script to execute inside pyction |
-
-## 📦 Example
+### As a CI job container
 
 ```yaml
-- name: Update fingerprints
-  uses: civicactions/pyction@v1
-  with:
-    script: |
-      uv sync
-      uv run scripts/fetch_fingerprints.py
+# GitHub Actions
+jobs:
+  run-python:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/civicactions/pyction:1
+    steps:
+      - uses: actions/checkout@v7
+      - run: |
+          uv sync
+          uv run scripts/fetch_fingerprints.py
 ```
+
+```yaml
+# GitLab CI
+run-python:
+  image: ghcr.io/civicactions/pyction:1
+  script:
+    - uv sync
+    - uv run your_script.py
+```
+
+## 🏷️ Tag policy
+
+| Tag | Meaning | Moves? |
+| ----- | --------- | ------ |
+| `latest` | Newest build, default Python (3.13) | ✅ daily |
+| `1` / `1.4` | Newest release in that major/minor line, default Python | ✅ per release |
+| `1.4.0` | Exact release, default Python | ❌ |
+| `py3.12` / `py3.13` / `py3.14` | Newest build for that Python version | ✅ daily |
+| `py3.12-1.4.0` etc. | Exact release for that Python version | ❌ |
+| `py3.13-<sha>` | Exact commit build | ❌ |
+
+**For production, pin by digest** (immune to tag repointing):
+
+```dockerfile
+FROM ghcr.io/civicactions/pyction:1.4.0@sha256:<digest>
+```
+
+Images are rebuilt daily at 04:00 UTC so `latest` and the `py3.X` aliases continuously pick up upstream Debian/Python security patches.
+
+## 💡 What's inside
+
+- `python:3.13-slim` (or 3.12 / 3.14 via the `py3.X` tags)
+- [`uv`](https://github.com/astral-sh/uv) + `uvx` — pinned version, updated monthly
+- `git`, `curl`, `unzip`, `ca-certificates`
+- `WORKDIR /app`
+- Multi-arch: `linux/amd64` + `linux/arm64`
+
+## 🔒 Security & provenance
+
+Every published image ships with automatically generated evidence:
+
+- **SBOM** (CycloneDX via Syft) — uploaded as a build artifact and fed to Dependency-Track for continuous vulnerability monitoring
+- **Cosign keyless signature** — verify with:
+
+  ```bash
+  cosign verify ghcr.io/civicactions/pyction:latest \
+    --certificate-identity-regexp 'https://github.com/CivicActions/pyction/.*' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+  ```
+
+- **SLSA provenance attestation** (BuildKit `mode=max`) — cryptographic proof of the source commit and build workflow
+- **Continuous scanning** via [Argus](https://github.com/huntridge-labs/argus) — container CVE scanning (Trivy + Grype), secrets, IaC, and supply-chain checks on every push, PR, and weekly schedule; results land in the repo Security tab
+- **Smoke-tested before push** — `python`, `uv`, `git`, `curl`, and `unzip` are verified working in every variant before any tag moves
 
 ## 🛠 Maintainers
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Monthly, single grouped PR. Base python image deliberately NOT pinned/bumped — the daily rebuild floats on python:X.Y-slim for automatic security patches.",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "schedule": ["* 0-8 1 * *"],
+  "timezone": "America/New_York",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 5,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Never bump the Python base image — PYTHON_VERSION is a deliberate, manual decision tied to the tag policy",
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["python"],
+      "enabled": false
+    },
+    {
+      "description": "Group everything else (uv, GitHub Actions, Argus pin) into one monthly PR",
+      "matchManagers": ["dockerfile", "github-actions"],
+      "groupName": "monthly dependency updates",
+      "groupSlug": "monthly-updates"
+    }
+  ]
+}


### PR DESCRIPTION
Pyction grows up: this PR turns it into a properly versioned, multi-Python, cryptographically verifiable base image — while keeping `latest` 100% backwards compatible for existing production consumers.

### 🚨 What consumers need to know

- **No action required** if you pull `latest`, `py3.13`, or semver tags — same Python 3.13, same tools (`uv`, `git`, `curl`, `unzip`), same paths.
- **Breaking:** branch-prefixed tags (`main-<sha>`, `<branch>-latest`) are no longer published. Use `py3.X-<sha>` or semver tags instead.
- **Breaking (docs):** the GitHub Action-style usage (`uses: civicactions/pyction@v1`) has been removed from the README — pyction is a base image, not an Action.

### ✨ What's new

**Multi-Python support**
- Build matrix for Python **3.12 / 3.13 / 3.14** (3.13 remains the default behind `latest`)
- New tag policy:

  | Tag | Meaning | Moves? |
  | --- | --- | --- |
  | `latest` | newest build, default Python | ✅ daily |
  | `1` / `1.4` / `1.4.0` | semver, default Python | per release / never |
  | `py3.12` / `py3.13` / `py3.14` | newest build per Python | ✅ daily |
  | `py3.X-1.4.0`, `py3.X-<sha>` | exact release / commit per Python | ❌ |

**Supply-chain hardening**
- 🔏 **Cosign keyless signing** on every pushed image
- 📜 **SLSA provenance attestations** (BuildKit `mode=max`) + BuildKit SBOMs
- 📌 `uv` is now **version-pinned** and installed from the official `ghcr.io/astral-sh/uv` image — no more `curl | bash`
- 🧪 **Smoke test before push**: `python`, `uv`, `uvx`, `git`, `curl`, `unzip` verified in every variant before any tag moves
- 🔒 Builds only run from `main` (plus cron/dispatch/release); concurrency guard prevents tag races

**Security scanning & evidence**
- Migrated from `hardening-workflows@main` to **[Argus](https://github.com/huntridge-labs/argus) `@1.7.0`** (versioned pin) — container CVE scanning (Trivy + Grype), secrets, IaC, and supply-chain checks with SARIF → Security tab; weekly drift-detection run added
- Per-variant **CycloneDX SBOM** artifacts; Dependency-Track upload now skips gracefully when secrets are absent

**Maintenance automation**
- **Renovate** config: one grouped PR per month (uv pin, Action digests, Argus pin) — the entire recurring human workload
- The Python base image deliberately **floats on `python:X.Y-slim`** so daily rebuilds pick up upstream security patches automatically

**Fixes & docs**
- `release-please` config now matches the actual `v`-prefixed tag history (`include-v-in-tag: true`); dropped the fragile Dockerfile version-regex replacement (version flows in via build arg)
- README rewritten as base-image documentation: Dockerfile / `docker run` / GitHub Actions / GitLab CI examples, tag policy, `cosign verify` instructions, digest-pinning guidance, new status badges

### ✅ Verification

- [x] Local builds green for py3.12 and py3.13 with full smoke-test suite
- [x] OCI labels resolve dynamically from build args
- [x] `actionlint` clean; all YAML/JSON validated
- [ ] Post-merge: confirm 3-variant matrix run, GHCR tags, SARIF in Security tab
- [ ] Post-release: `cosign verify`, semver + variant tags, `latest` digest unchanged in behavior
